### PR TITLE
Update sensor.py

### DIFF
--- a/custom_components/flow_power_ha/sensor.py
+++ b/custom_components/flow_power_ha/sensor.py
@@ -171,9 +171,15 @@ class FlowPowerBaseSensor(CoordinatorEntity[FlowPowerCoordinator], SensorEntity)
             tz = ZoneInfo(tz_name)
 
             if "/" in timestamp:
+                # AEMO slash format: "2026/06/16 13:30:00"
                 dt = datetime.strptime(timestamp, "%Y/%m/%d %H:%M:%S")
                 return dt.replace(tzinfo=tz)
-            return None
+            else: 
+                # ISO format: "2026-06-16T22:00:00+10:00" or "2026-06-16T22:00:00"
+                dt = datetime.fromisoformat(timestamp)
+                if dt.tzinfo is None:
+                    dt = dt.replace(tzinfo=tz)
+                return dt
         except (ValueError, TypeError):
             return None
 


### PR DESCRIPTION
This is the fix to address issue #16 "Price forecast apex values missing". 

In sensor.py under _parse_timestamp_to_datetime(), it's only set up to handle AEMO date time with / in them.

It looks like something changed recently, where the date is now ISO without the /. So the entire array evaluates to none.

Updated the code to handle ISO time format as well. 

I've tested the code on my local homeassistant and confirmed it has fixed the two apex array.