### PR TITLE
Fix: tariff refresh timer was resetting the coordinator's update schedule, starving real KWatch fetches

### DIFF
--- a/custom_components/flow_power_ha/coordinator.py
+++ b/custom_components/flow_power_ha/coordinator.py
@@ -210,7 +210,8 @@ class FlowPowerCoordinator(DataUpdateCoordinator[dict[str, Any]]):
                 self._network_tariff_rate = rate
                 data = self._current_data_with_updated_tariff(rate)
                 if data is not None:
-                    self.async_set_updated_data(data)
+                    self.data = data
+                    self.async_update_listeners()
                 _LOGGER.debug(
                     "Flow Power: Updated network tariff rate: %.4f c/kWh",
                     rate,


### PR DESCRIPTION
### Problem
`sensor.flow_power_xxxn_import_price` was failing to refresh on its normal 5-minute schedule, instead going stale for anywhere from 10 minutes to ~3 hours at a time (see issue #16). 

### Cause
_handle_tariff_refresh runs on its own clock-aligned 5-minute schedule (minute=[0,5,...,55]) and was calling self.async_set_updated_data(data) to push a tariff-adjusted copy of the last known price data. async_set_updated_data() also cancels and reschedules the coordinator's own automatic refresh timer. Since this tariff-only listener fires on essentially the same 5-minute cadence as the coordinator's real update interval, it kept resetting the schedule before _async_update_data() (the method that actually calls KWatch/AEMO) got a chance to run — so genuine price fetches only happened when something else forced a refresh (e.g. the Happy Hour listener's async_request_refresh()).

### Fix:
coordinator.py, in _handle_tariff_refresh:

#### Before
`self.async_set_updated_data(data)`

#### After
```
self.data = data
self.async_update_listeners()
```
Now async_update_listeners() pushes the updated state to sensors without touching the coordinator's scheduled refresh, so the tariff-only update no longer interferes with the real fetch cycle.

### Testing:
Ran locally for post-patch. KWatch price updates now fire every ~5 minutes as expected:

```
2026-06-21 19:35:24.121 INFO ... KWatch update — price=11.10 c/kWh, forecast_periods=64
2026-06-21 19:40:25.230 INFO ... KWatch update — price=11.53 c/kWh, forecast_periods=64
2026-06-21 19:45:26.372 INFO ... KWatch update — price=11.10 c/kWh, forecast_periods=64
2026-06-21 19:50:27.511 INFO ... KWatch update — price=11.45 c/kWh, forecast_periods=64
```

#### Logs prior
```
2026-06-21 17:35:00.330 DEBUG (MainThread) [custom_components.flow_power_ha.coordinator] Manually updated flow_power_ha data
2026-06-21 17:35:00.331 DEBUG (MainThread) [custom_components.flow_power_ha.coordinator] Flow Power: Updated network tariff rate: 16.9522 c/kWh
2026-06-21 17:40:00.449 DEBUG (MainThread) [custom_components.flow_power_ha.coordinator] Manually updated flow_power_ha data
2026-06-21 17:40:00.450 DEBUG (MainThread) [custom_components.flow_power_ha.coordinator] Flow Power: Updated network tariff rate: 16.9522 c/kWh
2026-06-21 17:45:00.351 DEBUG (MainThread) [custom_components.flow_power_ha.coordinator] Manually updated flow_power_ha data
2026-06-21 17:45:00.352 DEBUG (MainThread) [custom_components.flow_power_ha.coordinator] Flow Power: Updated network tariff rate: 16.9522 c/kWh
2026-06-21 17:50:00.373 DEBUG (MainThread) [custom_components.flow_power_ha.coordinator] Manually updated flow_power_ha data
2026-06-21 17:50:00.374 DEBUG (MainThread) [custom_components.flow_power_ha.coordinator] Flow Power: Updated network tariff rate: 16.9522 c/kWh
```

Closes #19 